### PR TITLE
Fix short.co urls appearing in final tweet. Closes #43

### DIFF
--- a/src/core/messager/MessageBreaker.py
+++ b/src/core/messager/MessageBreaker.py
@@ -22,7 +22,7 @@ def breakMessage(messageToBreak, tweetId, userId, userDataStrategy):
 
         else:
             if messageToBreak.rstrip() != "@%s"%(username):
-                splitMessageList.append(messageToBreak.rstrip())
+                splitMessageList.append(transformShortUrlsBackToOriginalLinks(messageToBreak.rstrip(), urls[:])[0])
             break
     return splitMessageList
 

--- a/src/core/tests/TestMessageSender.py
+++ b/src/core/tests/TestMessageSender.py
@@ -36,6 +36,19 @@ class TestMessageSender(unittest.TestCase):
 
     @patch.object(TweetAdapter, 'getUrlLengths')
     @patch.object(TweetAdapter, 'getUsernameForTweet')
+    def test_messageIsBrokenDownCorrectlyBeforeSendingWhenContainingLinks(self, patchMethod, urlLengthPatch):
+        user = User('test', '123456-012e1', '123h4123asdhh123', timezone(timedelta(hours = 5, minutes = 30)))
+        patchMethod.return_value = "example"
+        urlLengthPatch.return_value = (23,23)
+        mockUserDataStrategy = Mock()
+        mockUserDataStrategyAttrs = {"getUserById.return_value": user }
+        mockUserDataStrategy.configure_mock(**mockUserDataStrategyAttrs)
+        d = datetime.now(tz = timezone(timedelta(hours=5, minutes=30))) + timedelta(minutes=20)
+        replyToSend = Reply(1, "... Facebook biased - when did people give up on the process of getting informed? http://blog.theoldreader.com/post/144197778539/facebook-biased via @theoldreader", d, timezone(timedelta(hours=5, minutes=30)), 134953292, replyId = 1)
+        self.assertEqual(MessageBreaker.breakMessage(replyToSend.message, replyToSend.tweetId, 1, mockUserDataStrategy), ["... Facebook biased - when did people give up on the process of getting informed? http://blog.theoldreader.com/post/144197778539/facebook-biased via @theoldreader"])
+        
+    @patch.object(TweetAdapter, 'getUrlLengths')
+    @patch.object(TweetAdapter, 'getUsernameForTweet')
     def test_messageIsBrokenDownCorrectlyWhenMoreThan140Chars(self, patchMethod, urlLengthPatch):
         patchMethod.return_value = "example"
         urlLengthPatch.return_value = (23,23)


### PR DESCRIPTION
Discovered that the error was that if the shortened tweet with links was
less than 140 characters, it wasn't replacing the placeholders for
links. Fixed in this commit
